### PR TITLE
Super user creating while calling attribute api

### DIFF
--- a/src/api/attribute/list-store-attributes.ts
+++ b/src/api/attribute/list-store-attributes.ts
@@ -8,15 +8,6 @@ export default async (req, res) => {
   const attributeService: AttributeService =
     req.scope.resolve("attributeService");
 
-  const userService = req.scope.resolve("userService");
-  const regionService = req.scope.resolve("regionService");
-
-  await userService.create(
-    // @ts-ignore
-    { email: "admin@admin.com", role: "admin" },
-    "supersecret"
-  );
-
   res.json(
     await attributeService.list(validated, {
       where: { filterable: true },


### PR DESCRIPTION
Removed creating super user while calling /store/attributes.
It creates an error of existing user